### PR TITLE
Include 'as' argument in doc_upsert

### DIFF
--- a/R/doc_create.r
+++ b/R/doc_create.r
@@ -12,6 +12,7 @@
 #' @param how (character) One of rows (default) or columns. If rows, each row
 #' becomes a separate document; if columns, each column becomes a separate
 #' document.
+#' @param as (character) One of list (default) or json
 #'
 #' @details Documents can have attachments just like email. There are two ways
 #' to use attachments: the first one is via a separate REST call

--- a/R/doc_update.r
+++ b/R/doc_update.r
@@ -7,6 +7,7 @@
 #' @param doc (character) Document content. Required.
 #' @param docid (character) Document ID. Required.
 #' @param rev (character) Revision id. Required.
+#' @param as (character) One of list (default) or json
 #' @details Internally, this function adds in the docid and revision id,
 #' required to do a document update
 #' @examples \dontrun{

--- a/R/doc_upsert.R
+++ b/R/doc_upsert.R
@@ -6,6 +6,7 @@
 #' @param dbname (character) Database name. Required.
 #' @param doc (character) Document content. Required.
 #' @param docid (character) Document ID. Required.
+#' @param as (character) One of list (default) or json
 #' @details Internally, this function attempts to update a document with the given name. \cr
 #' If the document does not exist, it is created
 #' @author George Kritikos
@@ -30,16 +31,16 @@
 #'
 #' doc_get(x, dbname = "sofadb", docid = "abeer")
 #' }
-doc_upsert = function(cushion, dbname, doc, docid){
+doc_upsert = function(cushion, dbname, doc, docid, as = "list"){
   tryCatch({
     #try to update, if failed (record doesn't exist), create new entry
     revs = db_revisions(cushion = cushion, dbname = dbname, docid = docid)
     return(
-      doc_update(cushion = cushion, dbname = dbname, doc = doc, docid = docid, rev = revs[1])
+      doc_update(cushion = cushion, dbname = dbname, doc = doc, docid = docid, rev = revs[1], as = as)
     )
   }, error = function(e){
     return(
-      doc_create(cushion = cushion, dbname = dbname, doc = doc, docid = docid)
+      doc_create(cushion = cushion, dbname = dbname, doc = doc, docid = docid, as = as)
     )
   })
 }

--- a/man/doc_upsert.Rd
+++ b/man/doc_upsert.Rd
@@ -4,7 +4,7 @@
 \alias{doc_upsert}
 \title{Create a new document or update an existing one}
 \usage{
-doc_upsert(cushion, dbname, doc, docid)
+doc_upsert(cushion, dbname, doc, docid, as = "list")
 }
 \arguments{
 \item{cushion}{A \code{\link{Cushion}} object. Required.}
@@ -14,6 +14,8 @@ doc_upsert(cushion, dbname, doc, docid)
 \item{doc}{(character) Document content. Required.}
 
 \item{docid}{(character) Document ID. Required.}
+
+\item{as}{(character) One of list (default) or json}
 }
 \value{
 JSON as a character string or a list (determined by the

--- a/tests/testthat/test-doc_upsert.R
+++ b/tests/testthat/test-doc_upsert.R
@@ -79,4 +79,33 @@ test_that("doc_upsert fails well", {
   expect_error(doc_upsert(sofa_conn), "argument \"doc\" is missing")
 })
 
+
+test_that("doc_upsert - creating document works with json response", {
+  skip_on_cran()
+  
+  aa <- doc_upsert(sofa_conn, db, doc = doc1, docid = "j1", as = "json")
+  
+  expect_is(aa, "character")
+  expect_match(aa, "ok")
+  expect_match(aa, "true")
+  expect_match(aa, "id")
+  expect_match(aa, "rev")
+  expect_is(jsonlite::fromJSON(aa), "list")
+})
+
+
+test_that("doc_upsert - updating document works  with json response", {
+  skip_on_cran()
+  
+  aa <- doc_upsert(sofa_conn, db, doc = doc3, docid = "j1", as = "json")
+  
+  expect_is(aa, "character")
+  expect_match(aa, "ok")
+  expect_match(aa, "true")
+  expect_match(aa, "id")
+  expect_match(aa, "rev")
+  expect_is(jsonlite::fromJSON(aa), "list")
+  
+})
+
 cleanup_dbs(db)


### PR DESCRIPTION
## Description
The `doc_upsert` functions tries to update a document using the `doc_update` function and if that produces an error, creates a new document with `doc_create`. Both `doc_update` and `doc_create` allow an 'as' argument to define how the response is returned: either as a list or as a json. Thus, doc_upsert now allows the 'as' argument to be included and passes this argument to the other functions.

## Related Issue
No related issue

## Example
Direct usage of current `doc_upsert` example:

user <- Sys.getenv("COUCHDB_TEST_USER")
pwd <- Sys.getenv("COUCHDB_TEST_PWD")
(x <- Cushion$new(user=user, pwd=pwd))

if ("sofadb" %in% db_list(x)) {
  invisible(db_delete(x, dbname="sofadb"))
}
db_create(x, 'sofadb')

# create a document
doc1 <- '{"name": "drink", "beer": "IPA", "score": 5}'
doc_upsert(x, dbname="sofadb", doc1, docid="abeer")

#update the document
doc2 <- '{"name": "drink", "beer": "lager", "score": 6}'
doc_upsert(x, dbname="sofadb", doc2, docid="abeer", as = "json")
doc_upsert(x, dbname="sofadb", doc1, docid="abeer", as = "list)

Tests included in tests/test-doc_upsert.R